### PR TITLE
feat(guides_and_processes): OpenApi versioning policy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 > All things engineering: processes, best practices, setup guides, and more!
 
-* [📚 Catalyst Engineering](#-catalyst-engineering)
-  * [Getting Started](#getting-started)
-    * [Guides \& Processes](#guides--processes)
-    * [Style Guides](#style-guides)
-    * [Engineering Directory](#engineering-directory)
-    * [Repositories](#repositories)
-    * [Learning Resources](#learning-resources)
-  * [Support](#support)
-  * [License](#license)
+- [📚 Catalyst Engineering](#-catalyst-engineering)
+  - [Getting Started](#getting-started)
+    - [Guides \& Processes](#guides--processes)
+    - [Style Guides](#style-guides)
+    - [Engineering Directory](#engineering-directory)
+    - [Repositories](#repositories)
+    - [Learning Resources](#learning-resources)
+  - [Support](#support)
+  - [License](#license)
 
 ## Getting Started
 
@@ -29,6 +29,7 @@
 * [Refactoring Policy](guides_and_processes/refactoring_policy.md)
 * [Release Policy](guides_and_processes/release_policy.md)
 * [Releases](guides_and_processes/releases.md)
+* [OpenApi Versioning](guides_and_processes/openapi-versioning.md)
 
 ### Style Guides
 

--- a/guides_and_processes/openapi-versioning.md
+++ b/guides_and_processes/openapi-versioning.md
@@ -1,0 +1,15 @@
+# OpenApi Versioning
+
+* The version is specified in the format `MAJOR.MINOR.PATCH`, where `MAJOR`, `MINOR`, and `PATCH` are unsigned integer values.
+* The `MAJOR` version number **must** be aligned with the major releases of service and must represent a finalized set of `api/v{MAJOR}` endpoints. After a `MAJOR` version is released, no new endpoints with the same version prefix `v{MAJOR}` may be added.
+* The `MINOR` version number **must** be incremented if:
+  * backward-compatible or incompatible OpenAPI changes are made
+  * a new endpoint is added
+* The `PATCH` version number **must** be incremented if any minor cleanup is done, e.g., updates to the `title`, `description`, or `example` fields.
+
+
+## Referencing to the existing OpenApi spec file
+
+Any reference to an existing and properly versioned OpenAPI specification file must be made by referring to the defined [realease](./release_policy.md) using the following format:
+`<app_name>-openapi/vMAJOR.MINOR.PATCH`.
+The release version **must** match the specified version of the OpenAPI specification file.

--- a/guides_and_processes/openapi-versioning.md
+++ b/guides_and_processes/openapi-versioning.md
@@ -1,7 +1,10 @@
+<!-- cspell: OpenApi -->
+
 # OpenApi Versioning
 
 * The version is specified in the format `MAJOR.MINOR.PATCH`, where `MAJOR`, `MINOR`, and `PATCH` are unsigned integer values.
-* The `MAJOR` version number **must** be aligned with the major releases of service and must represent a finalized set of `api/v{MAJOR}` endpoints. After a `MAJOR` version is released, no new endpoints with the same version prefix `v{MAJOR}` may be added.
+* An OpenApi schema spec considered **stable** if the `MAJOR` version number is **odd**, e.g. `1.*.*`, `3.*.*` etc.
+* An OpenApi schema spec considered **unstable** if the `MAJOR` version number is **even**, e.g. `0.*.*`, `2.*.*` etc..
 * The `MINOR` version number **must** be incremented if:
   * backward-compatible or incompatible OpenAPI changes are made
   * a new endpoint is added
@@ -11,7 +14,9 @@
 ## Referencing to the existing OpenApi spec file
 
 *Any* reference to an existing OpenAPI specification file
-**must** be a reference the specified [realease](./release_policy.md) using the following format:
+**must** be a reference the specified [release](./release_policy.md) using the following format:
 `<app_name>-openapi/vMAJOR.MINOR.PATCH`.
 
 The release version **must** match the specified version of the OpenAPI specification file.
+
+OpenApi schema specification file **must** been attached to a release.

--- a/guides_and_processes/openapi-versioning.md
+++ b/guides_and_processes/openapi-versioning.md
@@ -10,6 +10,8 @@
 
 ## Referencing to the existing OpenApi spec file
 
-Any reference to an existing and properly versioned OpenAPI specification file must be made by referring to the defined [realease](./release_policy.md) using the following format:
+*Any* reference to an existing OpenAPI specification file
+**must** be a reference the specified [realease](./release_policy.md) using the following format:
 `<app_name>-openapi/vMAJOR.MINOR.PATCH`.
+
 The release version **must** match the specified version of the OpenAPI specification file.

--- a/guides_and_processes/openapi-versioning.md
+++ b/guides_and_processes/openapi-versioning.md
@@ -1,4 +1,4 @@
-<!-- cspell: OpenApi -->
+<!-- cspell: words openapi -->
 
 # OpenApi Versioning
 


### PR DESCRIPTION
Added a new `openapi-versiong.md` section, which defines a set of rules how to properly define a version of the OpenApi schema files and how to correctly reference to it.

Part of https://github.com/input-output-hk/catalyst-voices/issues/3363